### PR TITLE
Fix typo in root README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Substitute the values as necessary:
 
 **Be extra careful NOT to commit those changes, as they might leak potentially sensitive information!!!**
 
-As some extra safety consider running `git udpate-index --assume-unchanged src/assets/config/app.config.json` before changing this file.
+As some extra safety consider running `git update-index --assume-unchanged src/assets/config/app.config.json` before changing this file.
 
 
 


### PR DESCRIPTION
## What this PR changes/adds

- Fixes a typo

## Why it does that

- Prevent copy-paste errors

## Further notes

- Root README.md changed

## Linked Issue(s)

- None

